### PR TITLE
Bump packs to v2.19.0 and fix quest drop notifications

### DIFF
--- a/behaviour_pack/manifest.json
+++ b/behaviour_pack/manifest.json
@@ -7,11 +7,11 @@
 		]
 	},
 	"header": {
-		"name": "Amethyst BP v2.18.3",
+		"name": "Amethyst BP v2.19.0",
 		"description": "Extends Geode's capabilities with in-game access",
 		"min_engine_version": [ 1, 21, 70 ],
 		"uuid": "5f5ab0ea-79f8-4d1c-b283-0b7d05a538a9",
-		"version": "2.18.3"
+		"version": "2.19.0"
 	},
 	"modules": [
 		{
@@ -19,13 +19,13 @@
 			"language": "javascript",
 			"uuid": "c2758c76-c27c-4f04-add5-93951a2c32b8",
 			"entry": "scripts/main.js",
-			"version": "2.18.3"
+			"version": "2.19.0"
 		}
 	],
 	"dependencies": [
 		{
 			"uuid": "1ced0423-4bcf-4970-9749-b047e89d365c",
-			"version": "2.18.3"
+			"version": "2.19.0"
 		},
 		{
 			"module_name": "@minecraft/server",

--- a/behaviour_pack/scripts-dev/features/quests/progress-cache.ts
+++ b/behaviour_pack/scripts-dev/features/quests/progress-cache.ts
@@ -55,7 +55,7 @@ export default function loadQuestProgressCache() {
 
         QUEST_PROGRESS_CACHE.delete(thornyUser.thorny_id)
 
-        if (cached_quest_progress.status !== "completed") {
+        if (cached_quest_progress.status !== "completed" && cached_quest_progress.status !== "failed") {
             notifyOfQuestUpdate(player, `You have dropped your quest: ${cached_quest.title}`)
         }
     }

--- a/resource_pack/manifest.json
+++ b/resource_pack/manifest.json
@@ -7,17 +7,17 @@
 		]
 	},
 	"header": {
-		"name": "Amethyst RP v2.18.0",
+		"name": "Amethyst RP v2.19.0",
 		"description": "Extends Geode's capabilities with in-game access",
 		"min_engine_version": [ 1, 21, 70 ],
 		"uuid": "1ced0423-4bcf-4970-9749-b047e89d365c",
-		"version": "2.18.3-beta2"
+		"version": "2.19.0"
 	},
 	"modules": [
 		{
 			"type": "resources",
 			"uuid": "b95159c2-001d-4e26-bf8e-b60390e1f7cd",
-			"version": "2.18.0"
+			"version": "2.19.0"
 		}
 	],
 	"capabilities": [


### PR DESCRIPTION
---

### Description

- Updated `manifest.json` files in the resource and behavior packs to version 2.19.0.
- Fixed an issue where dropping failed quests triggered unnecessary notifications.

### Checklist

- [ ] The code compiles correctly.
- [ ] Tests have been written and passed.
- [ ] Relevant documentation has been updated.